### PR TITLE
rescue on Errno::ENETUNREACH, in port_in_use? method

### DIFF
--- a/lib/billy/proxy.rb
+++ b/lib/billy/proxy.rb
@@ -62,7 +62,7 @@ module Billy
       s.close
       Billy.log(:info, "puffing-billy: Waiting for event machine to shutdown on port #{port}")
       s
-    rescue Errno::ECONNREFUSED, Errno::EADDRNOTAVAIL
+    rescue Errno::ECONNREFUSED, Errno::EADDRNOTAVAIL, Errno::ENETUNREACH
       false
     end
 


### PR DESCRIPTION
Fix for the following issue: 
https://github.com/oesmith/puffing-billy/issues/246
